### PR TITLE
feat: add command `gum current` to show user config in current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,15 @@ Commands:
   use [options] <group-name>  Use one group name for user config
     --global                  Git global config
   delete <group-name>         Delete one group
+  current                     Show user config in current directory
   help [command]              display help for command
 ```
 
 ## Change Log
+
+### v1.0.6
+
+- feat: Add command `gum current` to show user config in current directory
 
 ### v1.0.5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gauseen/gum",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "git multiple user config manager",
   "bin": "./bin/index.js",
   "scripts": {},

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,16 @@ program
 
 program.command('delete <group-name>').description('Delete one group').action(onDelete);
 
+program
+  .command('current')
+  .description('Show user config in current directory')
+  .action(onCurrent);
+
 program.parse(process.argv);
+
+function printCurrentUser(using) {
+  printer(`Currently used name=${using.name} email=${using.email}`, 'yellow');
+}
 
 function onList() {
   const allConfig = getAllConfigInfo();
@@ -45,7 +54,7 @@ function onList() {
   const tableData = getPrintTableData(allConfig);
 
   // currently used user info
-  printer(`Currently used name=${using.name} email=${using.email}`, 'yellow');
+  printCurrentUser(using);
 
   // git user config group list
   const pt = new Table();
@@ -115,7 +124,7 @@ function onUse(groupName, options) {
       printer(`Global using name=${globalGitUser.name} email=${globalGitUser.email}`, 'green');
     }
 
-    printer(`Currently used name=${using.name} email=${using.email}`, 'yellow');
+    printCurrentUser(using);
     console.log(' ');
   } else {
     printer(`${groupName} is invalid group name`, 'red');
@@ -140,4 +149,9 @@ function onDelete(groupName) {
     printer(`Delete ${groupName} group success`, 'green');
     console.log(' ');
   });
+}
+
+function onCurrent() {
+  const using = getUsingGitUserConfig();
+  printCurrentUser(using);
 }


### PR DESCRIPTION
Excellent little tool that frees me from the pain of multiple git users!  Thanks a lot~

A small change has been added. I think this can better help users confirm the git account used in the current directory.

Hope to be able to download the latest version on npm soon : )